### PR TITLE
fix: bt_live minimal run on windows

### DIFF
--- a/bt_live/setup.py
+++ b/bt_live/setup.py
@@ -9,6 +9,8 @@ setup(
     name=package_name,
     version='1.0.0',
     packages=[package_name, package_name_django],
+    package_data={'': ['*.js']},
+    include_package_data=True,
     package_dir={
         package_name:
             os.path.join(

--- a/bt_live/src/bt_live/ros_node.py
+++ b/bt_live/src/bt_live/ros_node.py
@@ -1,4 +1,5 @@
 import os
+import tempfile
 
 from bt_view.bt_view import COLORS_PER_RETURN_STATE, draw_pygraphviz
 
@@ -66,7 +67,7 @@ class BtLiveNode(Node):
         if not os.path.exists(self.fbl_file):
             raise FileNotFoundError(
                 f'File under path fbl_file={self.fbl_file} does not exist.')
-        self.img_path = os.path.join('/tmp', 'bt_trace')
+        self.img_path = os.path.join(tempfile.gettempdir(), 'bt_trace')
         self.get_logger().info(f'{self.img_path=}')
 
         self.g = fbl_to_networkx(self.fbl_file)

--- a/bt_view/src/bt_view/bt_view.py
+++ b/bt_view/src/bt_view/bt_view.py
@@ -15,6 +15,7 @@
 from hashlib import sha256
 from math import log
 import os
+import tempfile
 from typing import Dict, List, Optional, Union
 
 from btlib import VALUE_MAP
@@ -33,7 +34,7 @@ WIDTH = 1920
 HEIGHT = 1080
 
 BG_IMG_FOLDER = os.path.join(
-    '/tmp',
+    tempfile.gettempdir(),
     'bt_imgs')
 NODE_WIDTH_IN = 2.5
 NODE_HEIGHT_IN = 0.8


### PR DESCRIPTION
Minimal fixes to make bt_live work (not throw an exception) on windows.

Note: while webpage will now display tree, it doesn't seem to live track the tree (all nodes are white). There are warnings about missing fonts

```sh
RuntimeWarning:   
(process:18672): Pango-WARNING **: 23:32:03.559: couldn't load font "Bitstream Vera Sans Mono Bold Not-Rotated 14", falling back to "Sans Bold Not-Rotated 14", expect ugly output.
```

... I see now it depends on a message provided by nav2 library to do the live updates